### PR TITLE
Make the API key and API host immediately usable from the AppConfig

### DIFF
--- a/StockPressure/AppConfig.cs
+++ b/StockPressure/AppConfig.cs
@@ -4,29 +4,33 @@ using System.Text;
 
 namespace GetShares
 {
-    public class AppConfig
+    public static class AppConfig
     {
         public static bool CheckForToday { get { return bool.Parse(ConfigurationManager.AppSettings["checkForToday"]); } }
         public static bool ShowVolumes { get { return bool.Parse(ConfigurationManager.AppSettings["showVolumes"]); } }
 
         public static decimal PressureLine { get { return decimal.Parse(ConfigurationManager.AppSettings["pressureLine"]); } }
 
+        private static string _apiKey = ConfigurationManager.AppSettings["apiKey"];
         public static string ApiKey
         {
-            get { return ConfigurationManager.AppSettings["apiKey"]; }
+            get { return _apiKey; }
             set
             {
+                _apiKey = value;
                 Configuration config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
                 config.AppSettings.Settings.Add("ApiKey", value);
                 config.Save();
             }
         }
 
+        private static string _apiHost = ConfigurationManager.AppSettings["apiHost"];
         public static string ApiHost
         {
-            get { return ConfigurationManager.AppSettings["apiHost"]; }
+            get { return _apiHost; }
             set
             {
+                _apiHost = value;
                 Configuration config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
                 config.AppSettings.Settings.Add("ApiHost", value);
                 config.Save();

--- a/StockPressure/Program.cs
+++ b/StockPressure/Program.cs
@@ -90,8 +90,8 @@ namespace GetShares
         private static YahooFinanceStatistics GetYahooFinanceForSymbol(string symbol)
         {
             YahooFinanceStatistics obj = null;
-            string apiKey = ConfigurationManager.AppSettings["ApiKey"];
-            string apiHost = ConfigurationManager.AppSettings["ApiHost"];
+            string apiKey = AppConfig.ApiKey;
+            string apiHost = AppConfig.ApiHost;
             if (YFCache.Has(symbol))
             {
                 obj = YFCache.Load(symbol);


### PR DESCRIPTION
When first started, the API key and API host stored in the AppConfig is not immediately usable because the AppConfih has to be reloaded.
Instead of reloading it, just use a backing field to store it. 